### PR TITLE
add DEBUG_NO_G3_SUPPORT (at main.h)

### DIFF
--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -49,6 +49,12 @@ bool CG3Protocol::Init(void)
     // base class
     ok = CProtocol::Init();
 
+#ifdef DEBUG_NO_G3_SUPPORT
+    // G3 support can be killed (currently for test purpose)
+    m_bStopThread = true;
+    return true;
+#endif
+
     // update reflector callsign
     m_ReflectorCallsign.PatchCallsign(0, (const uint8 *)"XLX", 3);
 

--- a/src/main.h
+++ b/src/main.h
@@ -64,6 +64,7 @@
 //#define DEBUG_NO_ERROR_ON_XML_OPEN_FAIL
 //#define DEBUG_DUMPFILE
 //#define DEBUG_NO_G3_ICMP_SOCKET
+//#define DEBUG_NO_G3_SUPPORT
 
 // reflector ---------------------------------------------------
 


### PR DESCRIPTION
To disable ICOM G3 support function for testing, add new definition.